### PR TITLE
Set python2-barbicanclient for RedHat 

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class barbican::params {
       $api_service_name             = 'openstack-barbican-api'
       $worker_package_name          = 'openstack-barbican-worker'
       $worker_service_name          = 'openstack-barbican-worker'
-      $client_package_name          = 'python-barbicanclient'
+      $client_package_name          = 'python2-barbicanclient'
       $barbican_wsgi_script_path    = '/var/www/cgi-bin/barbican'
       $barbican_wsgi_script_source  = '/usr/lib/python2.7/site-packages/barbican/api/app.wsgi'
       $dogtag_client_package        = 'pki-base'


### PR DESCRIPTION
Because in puppet4 yum package provider does "yum list
python-barbicanclient" and this does not work.

 - #CCCP-1278